### PR TITLE
:wrench:(cargo.toml): add local-offset feature to time crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,6 +3039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "oauth2"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4812,7 +4821,9 @@ dependencies = [
  "deranged",
  "itoa",
  "js-sys",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ reqwest = { version = "0.12.5", default-features = false, features = [
   "rustls-tls",
 ], optional = true }
 tracing = { version = "0.1.40" }
-time = { version = "0.3", features = ["macros", "formatting", "serde"] }
+time = { version = "0.3", features = [
+  "macros",
+  "formatting",
+  "serde",
+  "local-offset",
+] }
 serde = { version = "1.0.209", features = ["derive"] }
 serde_json = { version = "1.0.122", optional = true }
 config = { version = "0.14.0", features = ["convert-case"], optional = true }

--- a/src/components/card.rs
+++ b/src/components/card.rs
@@ -1,6 +1,7 @@
 use crate::shared::models::GuestbookEntry;
 use dioxus::prelude::*;
 use serde::Deserialize;
+use time::UtcOffset;
 #[derive(Props, Clone, Debug, PartialEq)]
 pub struct CardProps {
     card_type: CardType,
@@ -70,8 +71,11 @@ pub fn Card(props: CardProps) -> Element {
             close_button,
         } => {
             let sigb64 = entry.signature.clone().unwrap_or_default();
-            let date = entry
-                .created_at
+            let date = entry.created_at;
+            let offset = UtcOffset::local_offset_at(date).unwrap_or(date.offset());
+
+            let date = date
+                .to_offset(offset)
                 .format(time::macros::format_description!(
                     "[day] [month repr:short], [year], [hour repr:24]:[minute]"
                 ))


### PR DESCRIPTION
Update the time crate dependency in Cargo.toml to include the local-offset feature.

This is necessary to correctly handle the timezone offset when displaying the created_at date in the Card component.