### PR TITLE
:wrench:doc(env) add example environment configuration file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+DATABASE_URL=
+# Here comes my GH apps secret. You can't know it tho :) 
+# If you would like to test out oauth flow, consider creating a new github app and pasting its secret
+GABIOINF_SECRET=
+# This var is optional. It is set to localhost:8080 by defaultin debug builds and to 
+# some other domain specified in config/ in release builds
+DOMAIN_URL=http:://localhost:8080
+
+# Very much optional stuff needed for deployment and development only
+NEON_API_KEY=
+NEON_PROJECT_ID=
+SENTRY_DSN=
+FLY_API_KEY=
+RUST_LOG=debug


### PR DESCRIPTION
add .env.example file to provide a template for necessary environment variables
including database, API keys, and other configuration options.

Closes #85